### PR TITLE
fix: compilation errors

### DIFF
--- a/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferRequestValidator.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferRequestValidator.java
@@ -20,9 +20,6 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-
-import static java.lang.String.format;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateAccountName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateBlobName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateContainerName;
@@ -55,22 +52,17 @@ class AzureDataFactoryTransferRequestValidator {
     }
 
     private void validateSource(DataAddress source) {
-        var properties = new HashMap<>(source.getProperties());
-        validateBlobName(properties.remove(AzureBlobStoreSchema.BLOB_NAME));
-        validateProperties(properties);
+        validateBlobName(source.getProperty(AzureBlobStoreSchema.BLOB_NAME));
+        validateCommon(source);
     }
 
     private void validateDestination(DataAddress destination) {
-        var properties = new HashMap<>(destination.getProperties());
-        validateProperties(properties);
+        validateCommon(destination);
     }
 
-    private void validateProperties(HashMap<String, String> properties) {
-        validateAccountName(properties.remove(AzureBlobStoreSchema.ACCOUNT_NAME));
-        validateContainerName(properties.remove(AzureBlobStoreSchema.CONTAINER_NAME));
-        validateKeyName(properties.remove(DataAddress.KEY_NAME));
-        properties.keySet().stream().filter(k -> !DataAddress.TYPE.equals(k)).findFirst().ifPresent(k -> {
-            throw new IllegalArgumentException(format("Unexpected property %s", k));
-        });
+    private void validateCommon(DataAddress dataAddress) {
+        validateAccountName(dataAddress.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME));
+        validateContainerName(dataAddress.getProperty(AzureBlobStoreSchema.CONTAINER_NAME));
+        validateKeyName(dataAddress.getKeyName());
     }
 }

--- a/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/DataFactoryPipelineFactory.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/DataFactoryPipelineFactory.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.spi.types.domain.DataAddress.KEY_NAME;
 
 /**
  * Factory class for Azure Data Factory object definitions, such as pipelines and datasets.
@@ -102,7 +101,7 @@ class DataFactoryPipelineFactory {
                         .withConnectionString(String.format("DefaultEndpointsProtocol=https;AccountName=%s;", accountName))
                         .withAccountKey(
                                 new AzureKeyVaultSecretReference()
-                                        .withSecretName(dataAddress.getProperty(KEY_NAME))
+                                        .withSecretName(dataAddress.getKeyName())
                                         .withStore(new LinkedServiceReference()
                                                 .withReferenceName(keyVaultLinkedService)
                                         ))
@@ -112,7 +111,7 @@ class DataFactoryPipelineFactory {
 
     private LinkedServiceResource createDestinationLinkedService(String name, DataAddress dataAddress) {
         var accountName = dataAddress.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
-        var secret = keyVaultClient.getSecret(dataAddress.getProperty(KEY_NAME));
+        var secret = keyVaultClient.getSecret(dataAddress.getKeyName());
         var token = typeManager.readValue(secret.getValue(), AzureSasToken.class);
         var sasTokenSecret = keyVaultClient.setSecret(name, token.getSas());
 

--- a/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/TestFunctions.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/TestFunctions.java
@@ -30,20 +30,26 @@ public class TestFunctions {
 
     public static Map<String, String> sourceProperties() {
         var srcStorageAccount = createAccountName();
-        return Map.of(
-                AzureBlobStoreSchema.ACCOUNT_NAME, srcStorageAccount,
-                AzureBlobStoreSchema.CONTAINER_NAME, createContainerName(),
-                AzureBlobStoreSchema.BLOB_NAME, createBlobName(),
-                DataAddress.KEY_NAME, srcStorageAccount + "-key1");
+        return DataAddress.Builder.newInstance()
+                .type(AzureBlobStoreSchema.TYPE)
+                .keyName(srcStorageAccount + "-key1")
+                .property(AzureBlobStoreSchema.ACCOUNT_NAME, srcStorageAccount)
+                .property(AzureBlobStoreSchema.CONTAINER_NAME, createContainerName())
+                .property(AzureBlobStoreSchema.BLOB_NAME, createBlobName())
+                .build()
+                .getProperties();
     }
 
     public static Map<String, String> destinationProperties() {
         var destStorageAccount = createAccountName();
 
-        return Map.of(
-                AzureBlobStoreSchema.ACCOUNT_NAME, destStorageAccount,
-                AzureBlobStoreSchema.CONTAINER_NAME, createContainerName(),
-                DataAddress.KEY_NAME, destStorageAccount + "-key1");
+        return DataAddress.Builder.newInstance()
+                .type(AzureBlobStoreSchema.TYPE)
+                .keyName(destStorageAccount + "-key1")
+                .property(AzureBlobStoreSchema.ACCOUNT_NAME, destStorageAccount)
+                .property(AzureBlobStoreSchema.CONTAINER_NAME, createContainerName())
+                .build()
+                .getProperties();
     }
 
     public static DataFlowRequest createFlowRequest() {

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -34,7 +34,6 @@ import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateAccountName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateContainerName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateKeyName;
-import static org.eclipse.edc.spi.types.domain.DataAddress.KEY_NAME;
 
 /**
  * Instantiates {@link AzureStorageDataSink}s for requests whose source data type is {@link AzureBlobStoreSchema#TYPE}.
@@ -72,7 +71,7 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
         try {
             validateAccountName(dataAddress.getProperty(ACCOUNT_NAME));
             validateContainerName(dataAddress.getProperty(CONTAINER_NAME));
-            validateKeyName(dataAddress.getProperty(KEY_NAME));
+            validateKeyName(dataAddress.getKeyName());
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage destination address is invalid: " + e.getMessage());
         }

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -68,7 +67,7 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
             validateAccountName(dataAddress.getProperty(ACCOUNT_NAME));
             validateContainerName(dataAddress.getProperty(CONTAINER_NAME));
             validateBlobName(dataAddress.getProperty(BLOB_NAME));
-            validateKeyName(dataAddress.getProperty(DataAddress.KEY_NAME));
+            validateKeyName(dataAddress.getKeyName());
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage source address is invalid: " + e.getMessage());
         }

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
@@ -58,10 +58,10 @@ class AzureStorageDataSourceFactoryTest {
     @Test
     void validate_whenRequestValid_succeeds() {
         assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
+                                .keyName(accountName + "-key1")
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
-                                .property(DataAddress.KEY_NAME, accountName + "-key1")
                                 .build())
                         .build())
                 .succeeded()).isTrue();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ edc = "0.1.1-SNAPSHOT"
 failsafe = "3.3.1"
 httpMockServer = "5.15.0"
 jakarta-json = "2.0.1"
+junit = "5.9.3"
 mockito = "5.2.0"
 nimbus = "9.31"
 openTelemetry = "1.18.0"
@@ -79,8 +80,8 @@ opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", v
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
 jakartaJson = { module = "org.glassfish:jakarta.json", version.ref = "jakarta-json" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.9.3" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.9.3" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 edc-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
 mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "httpMockServer" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "httpMockServer" }

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferUtils.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferUtils.java
@@ -62,8 +62,7 @@ public class BlobTransferUtils {
                                 .add("contenttype", "text/plain")
                                 .add("version", "1.0"))
                 )
-                .add("dataAddress", createObjectBuilder()
-                        .add("properties", createObjectBuilder(dataAddressProperties)))
+                .add("dataAddress", createObjectBuilder(dataAddressProperties))
                 .build();
 
         return seedProviderData(ASSETS_PATH, requestBody);


### PR DESCRIPTION
## What this PR changes/adds

fix compilation errors

## Why it does that

ci

## Further notes

- Avoid the direct reference to the `DataAddress` `EDC_DATA_ADDRESS_KEY_NAME` preferring the use of the `keyName()` method
- Removed the "extra property" check, as it doesn't appear to be useful (an additional property on `DataAddress` shouldn't block the transfer)

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
