### PR TITLE
fix: use the getStringProperty method of the DataAddress

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -209,12 +209,12 @@ maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apa
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.28.0, Apache-2.0, approved, #9662
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, , restricted, clearlydefined
 maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.0.0-alpha, Apache-2.0, approved, #10044
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.18.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.28.0, Apache-2.0, approved, #9661
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, , restricted, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.18.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.28.0, Apache-2.0, approved, #9663
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, , restricted, clearlydefined
 maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.0.33, Apache-2.0, approved, #9687
 maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.0.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.projectreactor/reactor-core/3.4.30, Apache-2.0, approved, #7517

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResource.java
@@ -30,11 +30,11 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 public class ObjectContainerProvisionedResource extends ProvisionedDataDestinationResource {
 
     public String getAccountName() {
-        return getDataAddress().getProperty(ACCOUNT_NAME);
+        return getDataAddress().getStringProperty(ACCOUNT_NAME);
     }
 
     public String getContainerName() {
-        return getDataAddress().getProperty(CONTAINER_NAME);
+        return getDataAddress().getStringProperty(CONTAINER_NAME);
     }
 
     private ObjectContainerProvisionedResource() {

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerStatusChecker.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerStatusChecker.java
@@ -48,8 +48,8 @@ public class ObjectContainerStatusChecker implements StatusChecker {
                 }
             }
         } else {
-            var accountName = transferProcess.getDataRequest().getDataDestination().getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
-            var containerName = transferProcess.getDataRequest().getDataDestination().getProperty(AzureBlobStoreSchema.CONTAINER_NAME);
+            var accountName = transferProcess.getDataRequest().getDataDestination().getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
+            var containerName = transferProcess.getDataRequest().getDataDestination().getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME);
             return checkContainerExists(accountName, containerName);
         }
         throw new EdcException(format("No object container resource was associated with the transfer process: %s - cannot determine completion.", transferProcess));

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
@@ -31,8 +31,8 @@ public class ObjectStorageConsumerResourceDefinitionGenerator implements Consume
     public @Nullable ResourceDefinition generate(DataRequest dataRequest, Policy policy) {
         var destination = dataRequest.getDataDestination();
         var id = randomUUID().toString();
-        var account = destination.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
-        var container = destination.getProperty(AzureBlobStoreSchema.CONTAINER_NAME);
+        var account = destination.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
+        var container = destination.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME);
 
         if (container == null) {
             container = randomUUID().toString();

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResourceTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResourceTest.java
@@ -50,8 +50,8 @@ class ObjectContainerProvisionedResourceTest {
 
         assertThat(dest.getType()).isEqualTo(AzureBlobStoreSchema.TYPE);
         assertThat(dest.getKeyName()).isEqualTo("test-container");
-        assertThat(dest.getProperty(CONTAINER_NAME)).isEqualTo("test-container");
-        assertThat(dest.getProperty(ACCOUNT_NAME)).isEqualTo("test-account");
+        assertThat(dest.getStringProperty(CONTAINER_NAME)).isEqualTo("test-container");
+        assertThat(dest.getStringProperty(ACCOUNT_NAME)).isEqualTo("test-account");
     }
 
     @Test

--- a/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferManager.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferManager.java
@@ -86,8 +86,8 @@ public class AzureDataFactoryTransferManager {
         var dataAddress = request.getDestinationDataAddress();
         var secret = keyVaultClient.getSecret(dataAddress.getKeyName());
         var token = typeManager.readValue(secret.getValue(), AzureSasToken.class);
-        var accountName = dataAddress.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
-        var containerName = dataAddress.getProperty(AzureBlobStoreSchema.CONTAINER_NAME);
+        var accountName = dataAddress.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
+        var containerName = dataAddress.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME);
 
         var runId = client.runPipeline(pipeline).runId();
 

--- a/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferRequestValidator.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferRequestValidator.java
@@ -52,7 +52,7 @@ class AzureDataFactoryTransferRequestValidator {
     }
 
     private void validateSource(DataAddress source) {
-        validateBlobName(source.getProperty(AzureBlobStoreSchema.BLOB_NAME));
+        validateBlobName(source.getStringProperty(AzureBlobStoreSchema.BLOB_NAME));
         validateCommon(source);
     }
 
@@ -61,8 +61,8 @@ class AzureDataFactoryTransferRequestValidator {
     }
 
     private void validateCommon(DataAddress dataAddress) {
-        validateAccountName(dataAddress.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME));
-        validateContainerName(dataAddress.getProperty(AzureBlobStoreSchema.CONTAINER_NAME));
+        validateAccountName(dataAddress.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME));
+        validateContainerName(dataAddress.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME));
         validateKeyName(dataAddress.getKeyName());
     }
 }

--- a/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/DataFactoryPipelineFactory.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/edc/connector/dataplane/azure/datafactory/DataFactoryPipelineFactory.java
@@ -94,7 +94,7 @@ class DataFactoryPipelineFactory {
     }
 
     private LinkedServiceResource createSourceLinkedService(String name, DataAddress dataAddress) {
-        var accountName = dataAddress.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
+        var accountName = dataAddress.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
 
         return client.defineLinkedService(name)
                 .withProperties(new AzureStorageLinkedService()
@@ -110,7 +110,7 @@ class DataFactoryPipelineFactory {
     }
 
     private LinkedServiceResource createDestinationLinkedService(String name, DataAddress dataAddress) {
-        var accountName = dataAddress.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
+        var accountName = dataAddress.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
         var secret = keyVaultClient.getSecret(dataAddress.getKeyName());
         var token = typeManager.readValue(secret.getValue(), AzureSasToken.class);
         var sasTokenSecret = keyVaultClient.setSecret(name, token.getSas());
@@ -135,8 +135,8 @@ class DataFactoryPipelineFactory {
                         new BinaryDataset()
                                 .withLinkedServiceName(new LinkedServiceReference().withReferenceName(linkedService.name()))
                                 .withLocation(new AzureBlobStorageLocation()
-                                        .withFileName(dataAddress.getProperty(AzureBlobStoreSchema.BLOB_NAME))
-                                        .withContainer(dataAddress.getProperty(AzureBlobStoreSchema.CONTAINER_NAME))
+                                        .withFileName(dataAddress.getStringProperty(AzureBlobStoreSchema.BLOB_NAME))
+                                        .withContainer(dataAddress.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME))
                                 )
                 )
                 .create();

--- a/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferRequestValidatorTest.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryTransferRequestValidatorTest.java
@@ -40,8 +40,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class AzureDataFactoryTransferRequestValidatorTest {
     private static final DataFlowRequest.Builder REQUEST = createRequest(AzureBlobStoreSchema.TYPE);
 
-    private final Map<String, String> sourceProperties = TestFunctions.sourceProperties();
-    private final Map<String, String> destinationProperties = TestFunctions.destinationProperties();
+    private final Map<String, Object> sourceProperties = TestFunctions.sourceProperties();
+    private final Map<String, Object> destinationProperties = TestFunctions.destinationProperties();
     private final DataAddress.Builder source = createDataAddress(AzureBlobStoreSchema.TYPE);
     private final DataAddress.Builder destination = createDataAddress(AzureBlobStoreSchema.TYPE);
     AzureDataFactoryTransferRequestValidator validator = new AzureDataFactoryTransferRequestValidator();

--- a/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/TestFunctions.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/TestFunctions.java
@@ -28,7 +28,7 @@ import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.c
 
 public class TestFunctions {
 
-    public static Map<String, String> sourceProperties() {
+    public static Map<String, Object> sourceProperties() {
         var srcStorageAccount = createAccountName();
         return DataAddress.Builder.newInstance()
                 .type(AzureBlobStoreSchema.TYPE)
@@ -40,7 +40,7 @@ public class TestFunctions {
                 .getProperties();
     }
 
-    public static Map<String, String> destinationProperties() {
+    public static Map<String, Object> destinationProperties() {
         var destStorageAccount = createAccountName();
 
         return DataAddress.Builder.newInstance()

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -64,8 +64,8 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
     public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var dataAddress = request.getDestinationDataAddress();
         try {
-            validateAccountName(dataAddress.getProperty(ACCOUNT_NAME));
-            validateContainerName(dataAddress.getProperty(CONTAINER_NAME));
+            validateAccountName(dataAddress.getStringProperty(ACCOUNT_NAME));
+            validateContainerName(dataAddress.getStringProperty(CONTAINER_NAME));
             validateKeyName(dataAddress.getKeyName());
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage destination address is invalid: " + e.getMessage());
@@ -87,8 +87,8 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
         var token = typeManager.readValue(secret, AzureSasToken.class);
 
         return AzureStorageDataSink.Builder.newInstance()
-                .accountName(dataAddress.getProperty(ACCOUNT_NAME))
-                .containerName(dataAddress.getProperty(AzureBlobStoreSchema.CONTAINER_NAME))
+                .accountName(dataAddress.getStringProperty(ACCOUNT_NAME))
+                .containerName(dataAddress.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME))
                 .sharedAccessSignature(token.getSas())
                 .requestId(requestId)
                 .partitionSize(partitionSize)

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
@@ -59,9 +59,9 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
     public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var dataAddress = request.getSourceDataAddress();
         try {
-            validateAccountName(dataAddress.getProperty(ACCOUNT_NAME));
-            validateContainerName(dataAddress.getProperty(CONTAINER_NAME));
-            validateBlobName(dataAddress.getProperty(BLOB_NAME));
+            validateAccountName(dataAddress.getStringProperty(ACCOUNT_NAME));
+            validateContainerName(dataAddress.getStringProperty(CONTAINER_NAME));
+            validateBlobName(dataAddress.getStringProperty(BLOB_NAME));
             validateKeyName(dataAddress.getKeyName());
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage source address is invalid: " + e.getMessage());
@@ -76,11 +76,11 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
         var dataAddress = request.getSourceDataAddress();
 
         return AzureStorageDataSource.Builder.newInstance()
-                .accountName(dataAddress.getProperty(ACCOUNT_NAME))
-                .containerName(dataAddress.getProperty(CONTAINER_NAME))
+                .accountName(dataAddress.getStringProperty(ACCOUNT_NAME))
+                .containerName(dataAddress.getStringProperty(CONTAINER_NAME))
                 .sharedKey(vault.resolveSecret(dataAddress.getKeyName()))
                 .blobStoreApi(blobStoreApi)
-                .blobName(dataAddress.getProperty(BLOB_NAME))
+                .blobName(dataAddress.getStringProperty(BLOB_NAME))
                 .requestId(request.getId())
                 .retryPolicy(retryPolicy)
                 .monitor(monitor)


### PR DESCRIPTION
## What this PR changes/adds

Fixes compile errors that arose due to the `getProperty` -> `getStringProperty` transition in the `DataAddress` class.

## Why it does that

compile errors

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
