### PR TITLE
feat: Folder provisioning implementation

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -36,7 +36,7 @@ maven/mavencentral/com.azure/azure-core/1.43.0, MIT AND Apache-2.0, approved, #1
 maven/mavencentral/com.azure/azure-core/1.44.1, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.10.1, MIT AND Apache-2.0, approved, #10086
 maven/mavencentral/com.azure/azure-json/1.1.0, MIT AND Apache-2.0, approved, #10547
-maven/mavencentral/com.azure/azure-messaging-eventgrid/4.19.0, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-messaging-eventgrid/4.19.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-security-keyvault-keys/4.7.1, MIT, approved, #10872
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.7.0, MIT, approved, #10868
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.7.1, MIT, approved, #10868
@@ -182,6 +182,7 @@ maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.1.13, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.18, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.19, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.1.13, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.18, Apache-2.0, approved, #5929

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -33,7 +33,7 @@ maven/mavencentral/com.azure/azure-core-http-netty/1.13.9, MIT AND Apache-2.0, a
 maven/mavencentral/com.azure/azure-core-management/1.11.5, MIT, approved, #10033
 maven/mavencentral/com.azure/azure-core-management/1.11.7, MIT, approved, #10033
 maven/mavencentral/com.azure/azure-core/1.43.0, MIT AND Apache-2.0, approved, #10548
-maven/mavencentral/com.azure/azure-core/1.44.1, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.44.1, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.10.1, MIT AND Apache-2.0, approved, #10086
 maven/mavencentral/com.azure/azure-json/1.1.0, MIT AND Apache-2.0, approved, #10547
 maven/mavencentral/com.azure/azure-messaging-eventgrid/4.19.0, , restricted, clearlydefined
@@ -186,11 +186,11 @@ maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.1.13, Apache-2.0, a
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.18, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.1.13, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.18, , restricted, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.15, Apache-2.0, approved, #11475
+maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.18, Apache-2.0, approved, #11475
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.1.13, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.18, , restricted, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.15, Apache-2.0, approved, #11477
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.18, Apache-2.0, approved, #11477
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.1.13, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.15, Apache-2.0, approved, #5919
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.18, Apache-2.0, approved, #5919
@@ -409,21 +409,15 @@ maven/mavencentral/org.junit-pioneer/junit-pioneer/2.1.0, EPL-2.0, approved, #10
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.0, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.2, EPL-2.0, approved, #3133
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.0, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.1, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2, EPL-2.0, approved, #3125
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.0, EPL-2.0, approved, #9708
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.1, EPL-2.0, approved, #9708
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.2, EPL-2.0, approved, #3134
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.0, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.1, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.2, EPL-2.0, approved, #3130
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.0, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.1, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.2, EPL-2.0, approved, #3128
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.0, EPL-2.0, approved, #9704
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.1, EPL-2.0, approved, #9704
-maven/mavencentral/org.junit/junit-bom/5.10.0, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/AzureBlobStoreSchema.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/AzureBlobStoreSchema.java
@@ -27,6 +27,7 @@ public class AzureBlobStoreSchema {
     public static final String CONTAINER_NAME = "container";
     public static final String ACCOUNT_NAME = "account";
     public static final String BLOB_NAME = "blobName";
+    public static final String BLOB_PREFIX = "blobPrefix";
     public static final String FOLDER_NAME = "folderName";
     public static final String CORRELATION_ID = "correlationId";
 }

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/api/BlobStoreApi.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/api/BlobStoreApi.java
@@ -35,6 +35,16 @@ public interface BlobStoreApi {
 
     List<BlobItem> listContainer(String accountName, String containerName);
 
+    /**
+     * List all blobs from given folder in the container on a storage account.
+     *
+     * @param accountName The name of the storage account
+     * @param containerName The name of the container within the storage account
+     * @param directory The name of the folder within the container of the storage account
+     * @return Lazy loaded list of blobs from folder specified by the input parameters
+     */
+    List<BlobItem> listContainerFolder(String accountName, String containerName, String directory);
+
     void putBlob(String accountName, String containerName, String blobName, byte[] data);
 
     String createAccountSas(String accountName, String containerName, String racwxdl, OffsetDateTime expiry);

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/api/BlobStoreApiImpl.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/api/BlobStoreApiImpl.java
@@ -78,8 +78,7 @@ public class BlobStoreApiImpl implements BlobStoreApi {
 
     @Override
     public List<BlobItem> listContainerFolder(String accountName, String containerName, String directory) {
-        var options = new ListBlobsOptions()
-                .setPrefix(directory);
+        var options = new ListBlobsOptions().setPrefix(directory);
         return getBlobServiceClient(accountName).getBlobContainerClient(containerName).listBlobs(options, null).stream().toList();
     }
 

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/api/BlobStoreApiImpl.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/api/BlobStoreApiImpl.java
@@ -20,6 +20,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
@@ -76,6 +77,13 @@ public class BlobStoreApiImpl implements BlobStoreApi {
     }
 
     @Override
+    public List<BlobItem> listContainerFolder(String accountName, String containerName, String directory) {
+        var options = new ListBlobsOptions()
+                .setPrefix(directory);
+        return getBlobServiceClient(accountName).getBlobContainerClient(containerName).listBlobs(options, null).stream().toList();
+    }
+
+    @Override
     public void putBlob(String accountName, String containerName, String blobName, byte[] data) {
         var blobServiceClient = getBlobServiceClient(accountName);
         blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName).upload(BinaryData.fromBytes(data), true);
@@ -105,16 +113,15 @@ public class BlobStoreApiImpl implements BlobStoreApi {
         }
 
         var accountKey = vault.resolveSecret(accountName + "-key1");
-
-        if (accountKey == null) {
-            throw new IllegalArgumentException("No Object Storage credential found in vault!");
-        }
-
         var endpoint = createEndpoint(accountName);
-        var blobServiceClient = new BlobServiceClientBuilder()
-                .credential(createCredential(accountKey, accountName))
-                .endpoint(endpoint)
-                .buildClient();
+
+        var blobServiceClient = accountKey == null ?
+                new BlobServiceClientBuilder().credential(new DefaultAzureCredentialBuilder().build())
+                        .endpoint(endpoint)
+                        .buildClient() :
+                new BlobServiceClientBuilder().credential(createCredential(accountKey, accountName))
+                        .endpoint(endpoint)
+                        .buildClient();
 
         cache.put(accountName, blobServiceClient);
         return blobServiceClient;

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidator.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidator.java
@@ -51,7 +51,6 @@ public class AzureStorageValidator {
     private static final String INVALID_RESOURCE_NAME = "Invalid %s name";
     private static final String INVALID_RESOURCE_NAME_LENGTH = "Invalid %s name length, the name must be between %s and %s characters long";
     private static final String RESOURCE_NAME_EMPTY = "Invalid %s name, the name may not be null, empty or blank";
-    private static final String RESOURCE_NAME_NOT_EMPTY = "Invalid %s name, the name must be null or empty";
     private static final String TOO_MANY_PATH_SEGMENTS = "The number of URL path segments (strings between '/' characters) as part of the blob name cannot exceed %s.";
 
     /**
@@ -96,19 +95,6 @@ public class AzureStorageValidator {
     }
 
     /**
-     * Checks if a property value is empty.
-     *
-     * @param propertyValue A String representing the property value.
-     * @param propertyName A String representing the property name.
-     * @throws IllegalArgumentException if the property value is not empty.
-     */
-    public static void validateEmptyValue(String propertyValue, String propertyName) {
-        if (!StringUtils.isNullOrEmpty(propertyValue)) {
-            throw new IllegalArgumentException(String.format(RESOURCE_NAME_NOT_EMPTY, propertyName));
-        }
-    }
-
-    /**
      * Checks if a blob prefix is valid.
      * The restriction is based on Azure Blob Storage folder 'virtualization' which is base on the forward slash (/)
      * used in the blob path as delimiter. Prefix has to ends with '/'.
@@ -125,7 +111,6 @@ public class AzureStorageValidator {
         }
 
     }
-
 
     /**
      * Checks if a metadata value is valid.

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidator.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidator.java
@@ -35,6 +35,7 @@ public class AzureStorageValidator {
     private static final int BLOB_MAX_LENGTH = 1024;
     private static final int METADATA_MIN_LENGTH = 1;
     private static final int METADATA_MAX_LENGTH = 4096;
+    private static final int PATH_SEGMENTS_MAX = 254;
     private static final Pattern ACCOUNT_REGEX = Pattern.compile("^[a-z0-9]+$");
     private static final Pattern CONTAINER_REGEX = Pattern.compile("^[a-z0-9]+(-[a-z0-9]+)*$");
     private static final Pattern METADATA_REGEX = Pattern.compile("^[ -~]*$"); // US-ASCII
@@ -44,10 +45,14 @@ public class AzureStorageValidator {
     private static final String CONTAINER = "container";
     private static final String KEY_NAME = "keyName";
     private static final String METADATA = "metadata";
+    private static final String PREFIX = "prefix";
+
+    private static final String INVALID_PREFIX = "Invalid %s prefix, prefix must end with a '/' character";
     private static final String INVALID_RESOURCE_NAME = "Invalid %s name";
     private static final String INVALID_RESOURCE_NAME_LENGTH = "Invalid %s name length, the name must be between %s and %s characters long";
     private static final String RESOURCE_NAME_EMPTY = "Invalid %s name, the name may not be null, empty or blank";
-    private static final String TOO_MANY_PATH_SEGMENTS = "The number of URL path segments (strings between '/' characters) as part of the blob name cannot exceed 254.";
+    private static final String RESOURCE_NAME_NOT_EMPTY = "Invalid %s name, the name must be null or empty";
+    private static final String TOO_MANY_PATH_SEGMENTS = "The number of URL path segments (strings between '/' characters) as part of the blob name cannot exceed %s.";
 
     /**
      * Checks if an account name is valid.
@@ -87,13 +92,40 @@ public class AzureStorageValidator {
      */
     public static void validateBlobName(String blobName) {
         checkLength(blobName, BLOB, BLOB_MIN_LENGTH, BLOB_MAX_LENGTH);
+        checkSegments(blobName);
+    }
 
-        var slashCount = blobName.chars().filter(ch -> ch == '/').count();
-
-        if (slashCount >= 254) {
-            throw new IllegalArgumentException(TOO_MANY_PATH_SEGMENTS);
+    /**
+     * Checks if a property value is empty.
+     *
+     * @param propertyValue A String representing the property value.
+     * @param propertyName A String representing the property name.
+     * @throws IllegalArgumentException if the property value is not empty.
+     */
+    public static void validateEmptyValue(String propertyValue, String propertyName) {
+        if (!StringUtils.isNullOrEmpty(propertyValue)) {
+            throw new IllegalArgumentException(String.format(RESOURCE_NAME_NOT_EMPTY, propertyName));
         }
     }
+
+    /**
+     * Checks if a blob prefix is valid.
+     * The restriction is based on Azure Blob Storage folder 'virtualization' which is base on the forward slash (/)
+     * used in the blob path as delimiter. Prefix has to ends with '/'.
+     *
+     * @param blobPrefix A String representing the blob prefix to validate.
+     * @throws IllegalArgumentException if the string does not represent a valid prefix name.
+     */
+    public static void validateBlobPrefix(String blobPrefix) {
+        checkLength(blobPrefix, PREFIX, BLOB_MIN_LENGTH, BLOB_MAX_LENGTH);
+        checkSegments(blobPrefix);
+
+        if (!blobPrefix.endsWith("/")) {
+            throw new IllegalArgumentException(String.format(INVALID_PREFIX, blobPrefix));
+        }
+
+    }
+
 
     /**
      * Checks if a metadata value is valid.
@@ -131,6 +163,14 @@ public class AzureStorageValidator {
 
         if (name.length() < minLength || name.length() > maxLength) {
             throw new IllegalArgumentException(String.format(INVALID_RESOURCE_NAME_LENGTH, resourceType, minLength, maxLength));
+        }
+    }
+
+    private static void checkSegments(String name) {
+        var slashCount = name.chars().filter(ch -> ch == '/').count();
+
+        if (slashCount >= PATH_SEGMENTS_MAX) {
+            throw new IllegalArgumentException(String.format(TOO_MANY_PATH_SEGMENTS, PATH_SEGMENTS_MAX));
         }
     }
 }

--- a/extensions/common/azure/azure-blob-core/src/test/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidatorTest.java
+++ b/extensions/common/azure/azure-blob-core/src/test/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidatorTest.java
@@ -118,21 +118,6 @@ class AzureStorageValidatorTest {
                 .isThrownBy(() -> AzureStorageValidator.validateMetadata(input));
     }
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {  "" })
-    void validateEmptyValue_success(String input) {
-        AzureStorageValidator.validateEmptyValue(input, "TEST");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {  " ", "adab", "/", "123" })
-    void validateEmptyValue_fail(String input) {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> AzureStorageValidator.validateEmptyValue(input, "TEST"));
-    }
-
-
     private static class InvalidBlobNameProvider implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {

--- a/extensions/common/azure/azure-blob-core/src/test/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidatorTest.java
+++ b/extensions/common/azure/azure-blob-core/src/test/java/org/eclipse/edc/azure/blob/validator/AzureStorageValidatorTest.java
@@ -91,6 +91,20 @@ class AzureStorageValidatorTest {
     }
 
     @ParameterizedTest
+    @ArgumentsSource(ValidBlobPrefixProvider.class)
+    void validateBlobPrefix_success(String input) {
+        AzureStorageValidator.validateBlobPrefix(input);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(InvalidBlobPrefixProvider.class)
+    @NullSource
+    void validateBlobPrefix_fail(String input) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> AzureStorageValidator.validateBlobPrefix(input));
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {  "abcdefghijklmnop", "-", "a/%!_- $K1~"})
     void validateMetadata_success(String input) {
         AzureStorageValidator.validateMetadata(input);
@@ -103,6 +117,21 @@ class AzureStorageValidatorTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> AzureStorageValidator.validateMetadata(input));
     }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {  "" })
+    void validateEmptyValue_success(String input) {
+        AzureStorageValidator.validateEmptyValue(input, "TEST");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {  " ", "adab", "/", "123" })
+    void validateEmptyValue_fail(String input) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> AzureStorageValidator.validateEmptyValue(input, "TEST"));
+    }
+
 
     private static class InvalidBlobNameProvider implements ArgumentsProvider {
         @Override
@@ -126,6 +155,33 @@ class AzureStorageValidatorTest {
                     Arguments.of("je`~3j4k%$':\\"),
                     Arguments.of("abcdefghijklmnop".repeat(64)),
                     Arguments.of("a/b".repeat(253)));
+        }
+    }
+
+    private static class InvalidBlobPrefixProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    Arguments.of(""),
+                    Arguments.of("dfhjdhfjhsd"),
+                    Arguments.of("abcdefghijklmnop".repeat(64) + "/"),
+                    Arguments.of("a/b".repeat(253) + "/")
+                    );
+        }
+    }
+
+    private static class ValidBlobPrefixProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    Arguments.of("geq/"),
+                    Arguments.of("Qja143/"),
+                    Arguments.of("ABE/"),
+                    Arguments.of("a name/"),
+                    Arguments.of("end space /"),
+                    Arguments.of("je`~3j4k%$':\\/"),
+                    Arguments.of("abcdefghijklmnop".repeat(63) + "/"),
+                    Arguments.of("a/b".repeat(252) + "/"));
         }
     }
 

--- a/extensions/common/azure/azure-blob-core/src/testFixtures/java/org/eclipse/edc/azure/blob/testfixtures/AzureStorageTestFixtures.java
+++ b/extensions/common/azure/azure-blob-core/src/testFixtures/java/org/eclipse/edc/azure/blob/testfixtures/AzureStorageTestFixtures.java
@@ -50,6 +50,10 @@ public class AzureStorageTestFixtures {
         return "blob-" + UUID.randomUUID();
     }
 
+    public static String createBlobPrefix() {
+        return "blobFolder-" + UUID.randomUUID() + "/";
+    }
+
     public static String createSharedKey() {
         return "SK-" + UUID.randomUUID();
     }

--- a/extensions/data-plane/data-plane-azure-storage/README.md
+++ b/extensions/data-plane/data-plane-azure-storage/README.md
@@ -4,29 +4,26 @@
 
 This module contains a Data Plane extension to copy data to and from Azure Blob storage.
 
-When used as a source, it currently only supports copying a single blob.
+When used as a source, it supports copying a single or multiple blobs.
 
 The source `keyName` should reference a vault entry containing a storage [Shared Key](https://docs.microsoft.com/rest/api/storageservices/authorize-with-shared-key).
 
 The destination `keyName` should reference a vault entry containing a JSON-serialized `AzureSasToken` object wrapping a [storage access signature](https://docs.microsoft.com/azure/storage/common/storage-sas-overview).
 
-An example destination address:
-```json
-{
-    "dataDestination": {
-        "properties": {
-            "type": "AzureStorage",
-            "container": "containerName",
-            "account": "accountName",
-            "folderName": "test/",
-            "blobName": "new-name",
-            "keyName": "(see above)"
-        }
-    }
-}
-```
+### AzureStorage DataAddress Configuration
+
+The behavior of blobs transfers can be customized using DataAddress properties.
+
+- When blobPrefix is present, transfer all blobs with names that start with the specified prefix.
+- When blobPrefix is not present, transfer only the blob with a name matching the blobName property.
+- Precedence: blobPrefix takes precedence over blobName when determining which objects to transfer. It allows for both multiple blobs transfers and fetching a single blob when necessary.
+
+>Note: Using blobPrefix introduces an additional step to list all blobs whose name match the specified prefix.
+
 
 An example source address:
+
+- Single blob:
 ```json
 {
   "dataAddress": {
@@ -40,6 +37,52 @@ An example source address:
   }
 }
 ```
-The `folderName` and the `blobName` are optional properties.
+- Multiple blobs:
+```json
+{
+  "dataAddress": {
+    "properties": {
+      "type": "AzureStorage",
+      "container": "containerName",
+      "account": "accountName",
+      "blobPrefix": "test/",
+      "keyName": "(see above)"
+    }
+  }
+}
+```
+An example destination address:
+
+- Single blob:
+```json
+{
+    "dataDestination": {
+        "properties": {
+            "type": "AzureStorage",
+            "container": "containerName",
+            "account": "accountName",
+            "folderName": "destinationFolder/",
+            "blobName": "new-name",
+            "keyName": "(see above)"
+        }
+    }
+}
+```
+
+- Multiple blobs:
+```json
+{
+    "dataDestination": {
+        "properties": {
+            "type": "AzureStorage",
+            "container": "containerName",
+            "account": "accountName",
+            "folderName": "destinationFolder/",
+            "keyName": "(see above)"
+        }
+    }
+}
+```
+The `folderName` and the `blobName` are optional properties in destination address.
 
 

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSink.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSink.java
@@ -42,6 +42,7 @@ public class AzureStorageDataSink extends ParallelSink {
     private String containerName;
     private String folderName;
     private String blobName;
+    private String blobPrefix;
     private String sharedAccessSignature;
     private BlobStoreApi blobStoreApi;
     private DataFlowRequest request;
@@ -111,7 +112,7 @@ public class AzureStorageDataSink extends ParallelSink {
     }
 
     String getDestinationBlobName(String partName) {
-        var name = !StringUtils.isNullOrEmpty(blobName) ? blobName : partName;
+        var name = !StringUtils.isNullOrEmpty(blobName) && StringUtils.isNullOrBlank(blobPrefix) ? blobName : partName;
         if (!StringUtils.isNullOrEmpty(folderName)) {
             return folderName.endsWith("/") ? folderName + name : folderName + "/" + name;
         } else {
@@ -146,6 +147,11 @@ public class AzureStorageDataSink extends ParallelSink {
 
         public Builder blobName(String blobName) {
             sink.blobName = blobName;
+            return this;
+        }
+
+        public Builder blobPrefix(String blobPrefix) {
+            sink.blobPrefix = blobPrefix;
             return this;
         }
 

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -31,9 +31,12 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.ExecutorService;
 
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.ACCOUNT_NAME;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_NAME;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_PREFIX;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateAccountName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateContainerName;
+import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateEmptyValue;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateKeyName;
 
 /**
@@ -66,10 +69,15 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
     @Override
     public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var dataAddress = request.getDestinationDataAddress();
+        var dataSourceAddress = request.getSourceDataAddress();
+
         try {
             validateAccountName(dataAddress.getStringProperty(ACCOUNT_NAME));
             validateContainerName(dataAddress.getStringProperty(CONTAINER_NAME));
             validateKeyName(dataAddress.getKeyName());
+            if (dataSourceAddress.hasProperty(BLOB_PREFIX)) {
+                validateEmptyValue(dataAddress.getStringProperty(BLOB_NAME), BLOB_NAME);
+            }
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage destination address is invalid: " + e.getMessage());
         }

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.util.string.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ExecutorService;
@@ -36,7 +37,6 @@ import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_PREFIX;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateAccountName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateContainerName;
-import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateEmptyValue;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateKeyName;
 
 /**
@@ -76,7 +76,9 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
             validateContainerName(dataAddress.getStringProperty(CONTAINER_NAME));
             validateKeyName(dataAddress.getKeyName());
             if (dataSourceAddress.hasProperty(BLOB_PREFIX)) {
-                validateEmptyValue(dataAddress.getStringProperty(BLOB_NAME), BLOB_NAME);
+                if (!StringUtils.isNullOrBlank(BLOB_NAME)) {
+                    monitor.warning(String.format("Folder transfer, ignoring property %s", BLOB_NAME));
+                }
             }
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage destination address is invalid: " + e.getMessage());
@@ -92,6 +94,7 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
         }
 
         var dataAddress = request.getDestinationDataAddress();
+        var dataSourceAddress = request.getSourceDataAddress();
         var requestId = request.getId();
 
         var secret = vault.resolveSecret(dataAddress.getKeyName());
@@ -102,6 +105,7 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
                 .containerName(dataAddress.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME))
                 .folderName(dataAddress.getStringProperty(AzureBlobStoreSchema.FOLDER_NAME))
                 .blobName(dataAddress.getStringProperty(AzureBlobStoreSchema.BLOB_NAME))
+                .blobPrefix(dataSourceAddress.getStringProperty(BLOB_PREFIX))
                 .sharedAccessSignature(token.getSas())
                 .requestId(requestId)
                 .partitionSize(partitionSize)

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSource.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSource.java
@@ -55,7 +55,7 @@ public class AzureStorageDataSource implements DataSource {
     @Override
     public StreamResult<Stream<Part>> openPartStream() {
 
-        if (!StringUtils.isNullOrEmpty(blobPrefix)) {
+        if (!StringUtils.isNullOrBlank(blobPrefix)) {
             var folderBlobs = blobStoreApi.listContainerFolder(accountName, containerName, blobPrefix);
             if (folderBlobs.isEmpty()) {
                 monitor.severe(format("Error listing blobs in the container %s with prefix %s", containerName, blobPrefix));

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
@@ -28,9 +28,11 @@ import org.jetbrains.annotations.NotNull;
 
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.ACCOUNT_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_NAME;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_PREFIX;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateAccountName;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateBlobName;
+import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateBlobPrefix;
 import static org.eclipse.edc.azure.blob.validator.AzureStorageValidator.validateContainerName;
 
 /**
@@ -60,7 +62,11 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
         try {
             validateAccountName(dataAddress.getStringProperty(ACCOUNT_NAME));
             validateContainerName(dataAddress.getStringProperty(CONTAINER_NAME));
-            validateBlobName(dataAddress.getStringProperty(BLOB_NAME));
+            if (dataAddress.hasProperty(BLOB_PREFIX)) {
+                validateBlobPrefix(dataAddress.getStringProperty(BLOB_PREFIX));
+            } else {
+                validateBlobName(dataAddress.getStringProperty(BLOB_NAME));
+            }
         } catch (IllegalArgumentException e) {
             return Result.failure("AzureStorage source address is invalid: " + e.getMessage());
         }
@@ -78,6 +84,7 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
                 .containerName(dataAddress.getStringProperty(CONTAINER_NAME))
                 .blobStoreApi(blobStoreApi)
                 .blobName(dataAddress.getStringProperty(BLOB_NAME))
+                .blobPrefix(dataAddress.getStringProperty(BLOB_PREFIX))
                 .requestId(request.getId())
                 .retryPolicy(retryPolicy)
                 .monitor(monitor);

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createAccountName;
+import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobName;
+import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobPrefix;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createRequest;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,6 +53,8 @@ class AzureStorageDataSinkFactoryTest {
 
     private final String accountName = createAccountName();
     private final String containerName = createContainerName();
+    private final String blobName = createBlobName();
+    private final String blobPrefix = createBlobPrefix();
     private final String keyName = "test-keyname";
     private final AzureSasToken token = new AzureSasToken("test-writeonly-sas", new Random().nextLong());
 
@@ -73,6 +77,31 @@ class AzureStorageDataSinkFactoryTest {
                                 .build())
                         .build())
                 .succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenFolderRequestValid_succeeds() {
+        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
+                                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
+                                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
+                                .keyName(keyName)
+                                .build())
+                        .sourceDataAddress(dataAddress.property(AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix).build())
+                        .build())
+                .succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenFolderRequestInValid_fails() {
+        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
+                                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
+                                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
+                                .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
+                                .keyName(keyName)
+                                .build())
+                        .sourceDataAddress(dataAddress.property(AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix).build())
+                        .build())
+                .failed()).isTrue();
     }
 
     @Test

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -92,19 +92,6 @@ class AzureStorageDataSinkFactoryTest {
     }
 
     @Test
-    void validate_whenFolderRequestInValid_fails() {
-        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
-                                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
-                                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
-                                .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
-                                .keyName(keyName)
-                                .build())
-                        .sourceDataAddress(dataAddress.property(AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix).build())
-                        .build())
-                .failed()).isTrue();
-    }
-
-    @Test
     void validate_whenMissingAccountName_fails() {
         assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createAccountName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobName;
+import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobPrefix;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createRequest;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createSharedKey;
@@ -43,6 +44,7 @@ class AzureStorageDataSourceFactoryTest {
     private final String accountName = createAccountName();
     private final String containerName = createContainerName();
     private final String blobName = createBlobName();
+    private final String blobPrefix = createBlobPrefix();
     private final String sharedKey = createSharedKey();
 
     @Test
@@ -56,12 +58,24 @@ class AzureStorageDataSourceFactoryTest {
     }
 
     @Test
-    void validate_whenRequestValid_succeeds() {
+    void validate_whenBlobRequestValid_succeeds() {
         assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
                                 .keyName(accountName + "-key1")
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
+                                .build())
+                        .build())
+                .succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenBlobFolderRequestValid_succeeds() {
+        assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
+                                .keyName(accountName + "-key1")
+                                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
+                                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
+                                .property(AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix)
                                 .build())
                         .build())
                 .succeeded()).isTrue();
@@ -88,7 +102,7 @@ class AzureStorageDataSourceFactoryTest {
     }
 
     @Test
-    void validate_whenMissingBlobName_fails() {
+    void validate_whenMissingBlobNameAndBlobPrefix_fails() {
         assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.azure.storage.pipeline;
 
+import com.azure.storage.blob.models.BlobItem;
 import dev.failsafe.RetryPolicy;
 import org.eclipse.edc.azure.blob.AzureBlobStoreSchema;
 import org.eclipse.edc.azure.blob.adapter.BlobAdapter;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.util.List;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -33,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createAccountName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobName;
+import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobPrefix;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createRequest;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createSharedKey;
@@ -50,6 +53,7 @@ class AzureStorageDataSourceTest {
     String containerName = createContainerName();
     String sharedKey = createSharedKey();
     String blobName = createBlobName();
+    String blobPrefix = createBlobPrefix();
     String content = "Test Content";
 
     Exception exception = new TestCustomException("Test exception message");
@@ -64,7 +68,19 @@ class AzureStorageDataSourceTest {
             .blobStoreApi(blobStoreApi)
             .monitor(monitor)
             .build();
+
+    AzureStorageDataSource dataSourceFolder = AzureStorageDataSource.Builder.newInstance()
+            .accountName(accountName)
+            .containerName(containerName)
+            .blobPrefix(blobPrefix)
+            .sharedKey(sharedKey)
+            .requestId(request.build().getId())
+            .retryPolicy(RetryPolicy.ofDefaults())
+            .blobStoreApi(blobStoreApi)
+            .monitor(monitor)
+            .build();
     BlobAdapter destination = mock();
+    BlobItem blobItem = mock();
     ByteArrayInputStream input = new ByteArrayInputStream(content.getBytes(UTF_8));
 
     @BeforeEach
@@ -79,8 +95,21 @@ class AzureStorageDataSourceTest {
     }
 
     @Test
-    void openPartStream_succeeds() {
+    void openPartStreamBlob_succeeds() {
         var result = dataSource.openPartStream().getContent();
+        assertThat(result).map(DataSource.Part::openStream).containsExactly(input);
+    }
+
+    @Test
+    void openPartStreamBlobs_succeeds() {
+        when(blobStoreApi.listContainerFolder(
+                accountName,
+                containerName,
+                blobPrefix))
+                .thenReturn(List.of(blobItem));
+        when(blobItem.getName()).thenReturn(blobName);
+
+        var result = dataSourceFolder.openPartStream().getContent();
         assertThat(result).map(DataSource.Part::openStream).containsExactly(input);
     }
 

--- a/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
+++ b/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
@@ -48,6 +48,26 @@ public class BlobTransferParticipant extends Participant {
         return createAsset(assetId, properties, dataAddressProperties);
     }
 
+    public String createBlobPrefixAsset(String accountName, String containerName, String blobPrefix) {
+        var assetId = UUID.randomUUID().toString();
+
+        Map<String, Object> dataAddressProperties = Map.of(
+                "type", AzureBlobStoreSchema.TYPE,
+                AzureBlobStoreSchema.ACCOUNT_NAME, accountName,
+                AzureBlobStoreSchema.CONTAINER_NAME, containerName,
+                AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix,
+                "keyName", format("%s-key1", accountName)
+        );
+
+        Map<String, Object> properties = Map.of(
+                "name", assetId,
+                "contenttype", "text/directory",
+                "version", "1.0"
+        );
+
+        return createAsset(assetId, properties, dataAddressProperties);
+    }
+
     public Map<String, Object> getDataDestination(String transferProcessId) {
         return given()
                 .baseUri(managementEndpoint.getUrl().toString())

--- a/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
+++ b/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
@@ -48,7 +48,7 @@ public class BlobTransferParticipant extends Participant {
         return createAsset(assetId, properties, dataAddressProperties);
     }
 
-    public String createBlobPrefixAsset(String accountName, String containerName, String blobPrefix) {
+    public String createBlobInFolderAsset(String accountName, String containerName, String blobPrefix) {
         var assetId = UUID.randomUUID().toString();
 
         Map<String, Object> dataAddressProperties = Map.of(

--- a/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferValidator.java
+++ b/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferValidator.java
@@ -25,16 +25,18 @@ public class BlobTransferValidator implements ThrowingConsumer<Map<String, Objec
 
     private final BlobServiceClient client;
     private final String expectedContent;
+    private final String expectedName;
 
-    public BlobTransferValidator(BlobServiceClient client, String expectedContent) {
+    public BlobTransferValidator(BlobServiceClient client, String expectedContent, String expectedName) {
         this.client = client;
         this.expectedContent = expectedContent;
+        this.expectedName = expectedName;
     }
-    
+
     @Override
     public void acceptThrows(Map<String, Object> destinationProperties) {
         var container = (String) destinationProperties.get("container");
-        var destinationBlob = client.getBlobContainerClient(container).getBlobClient(ProviderConstants.ASSET_FILE);
+        var destinationBlob = client.getBlobContainerClient(container).getBlobClient(expectedName);
         assertThat(destinationBlob.exists())
                 .withFailMessage("Destination blob %s not created", destinationBlob.getBlobUrl())
                 .isTrue();

--- a/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/ProviderConstants.java
+++ b/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/ProviderConstants.java
@@ -28,6 +28,7 @@ public interface ProviderConstants {
     int PROTOCOL_PORT = getFreePort();
     String PROTOCOL_PATH = "/protocol";
     String PROTOCOL_URL = "http://localhost:" + PROTOCOL_PORT + PROTOCOL_PATH;
+    String ASSET_PREFIX = "folderName/";
     String ASSET_FILE = "text-document.txt";
     String MANAGEMENT_URL = "http://localhost:" + MANAGEMENT_PORT + MANAGEMENT_PATH;
     URI CONTROL_URL = URI.create("http://localhost:" + getFreePort() + "/control");

--- a/system-tests/azure-blob-transfer-tests/src/test/java/org/eclipse/edc/test/system/blob/BlobTransferIntegrationTest.java
+++ b/system-tests/azure-blob-transfer-tests/src/test/java/org/eclipse/edc/test/system/blob/BlobTransferIntegrationTest.java
@@ -120,7 +120,7 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
         }
 
         // Seed data to provider
-        var assetId = blobsToTransfer.length > 1 ? providerClient.createBlobPrefixAsset(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, assetName)
+        var assetId = blobsToTransfer.length > 1 ? providerClient.createBlobInFolderAsset(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, assetName)
                 : providerClient.createBlobAsset(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, assetName);
         var policyId = providerClient.createPolicyDefinition(PolicyFixtures.noConstraintPolicy());
         providerClient.createContractDefinition(assetId, UUID.randomUUID().toString(), policyId, policyId);

--- a/system-tests/azure-blob-transfer-tests/src/test/java/org/eclipse/edc/test/system/blob/BlobTransferIntegrationTest.java
+++ b/system-tests/azure-blob-transfer-tests/src/test/java/org/eclipse/edc/test/system/blob/BlobTransferIntegrationTest.java
@@ -25,13 +25,18 @@ import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.test.system.utils.Participant;
 import org.eclipse.edc.test.system.utils.PolicyFixtures;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
@@ -101,17 +106,22 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
             .protocolEndpoint(new Participant.Endpoint(URI.create(ProviderConstants.PROTOCOL_URL)))
             .build();
 
-    @Test
-    void transferBlob_success() {
+    @ParameterizedTest
+    @ArgumentsSource(BlobNamesToTransferProvider.class)
+    void transferBlob_success(String assetName, String[] blobsToTransfer) {
         // Arrange
         // Upload a blob with test data on provider blob container (in account1).
         createContainer(providerBlobServiceClient, PROVIDER_CONTAINER_NAME);
-        providerBlobServiceClient.getBlobContainerClient(PROVIDER_CONTAINER_NAME)
-                .getBlobClient(ProviderConstants.ASSET_FILE)
-                .upload(BinaryData.fromString(BLOB_CONTENT));
+
+        for (String blobToTransfer : blobsToTransfer) {
+            providerBlobServiceClient.getBlobContainerClient(PROVIDER_CONTAINER_NAME)
+                    .getBlobClient(blobToTransfer)
+                    .upload(BinaryData.fromString(BLOB_CONTENT));
+        }
 
         // Seed data to provider
-        var assetId = providerClient.createBlobAsset(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, ProviderConstants.ASSET_FILE);
+        var assetId = blobsToTransfer.length > 1 ? providerClient.createBlobPrefixAsset(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, assetName)
+                : providerClient.createBlobAsset(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, assetName);
         var policyId = providerClient.createPolicyDefinition(PolicyFixtures.noConstraintPolicy());
         providerClient.createContractDefinition(assetId, UUID.randomUUID().toString(), policyId, policyId);
 
@@ -129,7 +139,21 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
         var blobServiceClient = TestFunctions.getBlobServiceClient(CONSUMER_STORAGE_ACCOUNT_NAME, CONSUMER_STORAGE_ACCOUNT_KEY, "http://127.0.0.1:%s/%s".formatted(AZURITE_PORT, CONSUMER_STORAGE_ACCOUNT_NAME));
 
         var dataDestination = consumerClient.getDataDestination(transferProcessId);
-        assertThat(dataDestination).satisfies(new BlobTransferValidator(blobServiceClient, BLOB_CONTENT));
+        for (String blobToTransfer : blobsToTransfer) {
+            assertThat(dataDestination).satisfies(new BlobTransferValidator(blobServiceClient, BLOB_CONTENT, blobToTransfer));
+        }
     }
 
+    private static class BlobNamesToTransferProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    Arguments.of(ProviderConstants.ASSET_PREFIX, (Object) new String[]{
+                            ProviderConstants.ASSET_PREFIX + 1 + ProviderConstants.ASSET_FILE,
+                            ProviderConstants.ASSET_PREFIX + 2 + ProviderConstants.ASSET_FILE,
+                            ProviderConstants.ASSET_PREFIX + 3 + ProviderConstants.ASSET_FILE}),
+                    Arguments.of(ProviderConstants.ASSET_FILE, (Object) new String[]{
+                            ProviderConstants.ASSET_FILE}));
+        }
+    }
 }

--- a/system-tests/azure-data-factory-tests/src/test/java/org/eclipse/edc/test/system/blob/AzureDataFactoryTransferIntegrationTest.java
+++ b/system-tests/azure-data-factory-tests/src/test/java/org/eclipse/edc/test/system/blob/AzureDataFactoryTransferIntegrationTest.java
@@ -153,7 +153,7 @@ class AzureDataFactoryTransferIntegrationTest {
         });
 
         var dataDestination = consumerClient.getDataDestination(transferProcessId);
-        assertThat(dataDestination).satisfies(new BlobTransferValidator(blobServiceClient, BLOB_CONTENT));
+        assertThat(dataDestination).satisfies(new BlobTransferValidator(blobServiceClient, BLOB_CONTENT, ProviderConstants.ASSET_FILE));
     }
 
     @AfterAll


### PR DESCRIPTION
## What this PR changes/adds

This PR adds support for multiple blobs transfer

## Why it does that

Currently, the extension only supports transfer of single blob. It does not support like for example AWS extension does - registering source data address as 'folder' by specifying blob path prefix. It would be most likely of interest to all parties integrating the EDC on Azure to use such feature.

## Further notes

Additionally this PR  adjust existing integration test BlobTransferIntegrationTest to test single blob transfer as well as multiple blobs transfer.

It would be preferred to have this change already in 0.3.2-SNAPSHOT if possible  (together with our previous merged contribution #77)

## Linked Issue(s)

Closes #91
