### PR TITLE
fix: add mandatory transfer type

### DIFF
--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/AzureBlobStoreSchema.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/AzureBlobStoreSchema.java
@@ -20,14 +20,14 @@ package org.eclipse.edc.azure.blob;
  */
 public class AzureBlobStoreSchema {
 
-    private AzureBlobStoreSchema() {
-    }
-
     public static final String TYPE = "AzureStorage";
+    public static final String TRANSFERTYPE_PUSH = TYPE + "-PUSH";
     public static final String CONTAINER_NAME = "container";
     public static final String ACCOUNT_NAME = "account";
     public static final String BLOB_NAME = "blobName";
     public static final String BLOB_PREFIX = "blobPrefix";
     public static final String FOLDER_NAME = "folderName";
     public static final String CORRELATION_ID = "correlationId";
+    private AzureBlobStoreSchema() {
+    }
 }

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/AzureBlobStoreSchema.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/AzureBlobStoreSchema.java
@@ -28,6 +28,7 @@ public class AzureBlobStoreSchema {
     public static final String BLOB_PREFIX = "blobPrefix";
     public static final String FOLDER_NAME = "folderName";
     public static final String CORRELATION_ID = "correlationId";
+    
     private AzureBlobStoreSchema() {
     }
 }

--- a/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
+++ b/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
@@ -86,7 +86,11 @@ public class BlobTransferParticipant extends Participant {
                         .add(AzureBlobStoreSchema.ACCOUNT_NAME, accountName))
                 .build();
 
-        return super.requestAsset(provider, assetId, createObjectBuilder().build(), destination);
+        return this.requestAssetFrom(assetId, provider)
+                .withPrivateProperties(createObjectBuilder().build())
+                .withDestination(destination)
+                .withTransferType(AzureBlobStoreSchema.TRANSFERTYPE_PUSH)
+                .execute();
     }
 
     public static final class Builder extends Participant.Builder<BlobTransferParticipant, Builder> {


### PR DESCRIPTION
## What this PR changes/adds

Adds the `transferType = AzureStorage-PUSH` field to tests
## Why it does that

`transferType` is now mandatory

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
