### PR TITLE
fix(ci): set version before tests, publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,6 +50,8 @@ jobs:
     needs: [ Secrets-Presence, Determine-Version ]
     uses: ./.github/workflows/verify.yaml
     secrets: inherit
+    with:
+      version: ${{ needs.Determine-Version.outputs.VERSION }}
 
   Publish-Artefacts:
     runs-on: ubuntu-latest
@@ -68,6 +70,13 @@ jobs:
         name: "Import GPG Key"
         with:
           gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+
+      - name: Set correct version
+        env:
+          VERSION: ${{ needs.Determine-Version.outputs.VERSION }}
+        run: |
+          existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+          grep -rlz "$existingVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$existingVersion/$VERSION/g"
 
       - name: "Publish To OSSRH/MavenCentral"
         if: |

--- a/.github/workflows/release-tech-az.yml
+++ b/.github/workflows/release-tech-az.yml
@@ -48,8 +48,8 @@ jobs:
       edc-version: ${{ env.EDC_VERSION }}
 
   Github-Release:
-    # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
-    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    # only bump the version for releases, no snapshots, no bugfixes/patches
+    if: ${{ endsWith( needs.Prepare-Release.outputs.edc-version, '.0') }}
     needs:
       - Prepare-Release
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,17 @@ name: Run Tests
 
 on:
   workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: optional version of upstream EDC components to use
   workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: optional version of upstream EDC components to use
   push:
   pull_request:
     branches: [ main ]
@@ -11,6 +21,9 @@ on:
       - 'docs/**'
       - 'CODEOWNERS'
       - 'LICENSE'
+
+env:
+  VERSION: ${{ github.event.inputs.version || inputs.version }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +40,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+          echo "set EDC version to ${{ env.VERSION }}"
+          existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+          sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+
+          # some debug print
+          head -20 gradle/libs.versions.toml
+          fi
+
       - name: Run Checkstyle
         run: ./gradlew --refresh-dependencies checkstyleMain checkstyleTest checkstyleTestFixtures
 
@@ -37,6 +62,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Run unit tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
@@ -49,6 +85,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Azure Storage Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
@@ -104,6 +152,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
+
       - name: Component Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
         with:
@@ -114,7 +174,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
 
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
       - name: End to End Integration Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
         with:
@@ -127,6 +197,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Component Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -59,7 +59,7 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.12.1, Apache
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.13.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.0, Apache-2.0, approved, #13672
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.1, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.2, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.13.5, Apache-2.0, approved, #2133
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.2, Apache-2.0 AND MIT, approved, #4303
@@ -69,7 +69,7 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.4.2, Apache-
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.5, Apache-2.0, approved, #2134
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.2, Apache-2.0, approved, #15232
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.0, Apache-2.0, approved, #13671
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.1, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.13.5, Apache-2.0, approved, #3768
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.17.2, Apache-2.0, approved, #13666
@@ -85,7 +85,7 @@ maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.2
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.17.2, Apache-2.0, approved, #14194
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.2, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.17.2, Apache-2.0, approved, #14195
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.0, Apache-2.0, approved, #13668
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.1, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.2, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.2, Apache-2.0, approved, #14162
 maven/mavencentral/com.fasterxml.woodstox/woodstox-core/6.7.0, Apache-2.0, approved, #15476
@@ -95,13 +95,13 @@ maven/mavencentral/com.github.docker-java/docker-java-transport/3.4.0, Apache-2.
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, CC-BY-2.5, approved, #15220
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.crypto.tink/tink/1.13.0, Apache-2.0, approved, #14502
+maven/mavencentral/com.google.crypto.tink/tink/1.14.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.26.1, Apache-2.0, approved, #13657
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/33.2.0-jre, Apache-2.0 AND CC0-1.0 AND (Apache-2.0 AND CC-PDDC), approved, #14607
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
-maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.25.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.microsoft.azure/msal4j-persistence-extension/1.3.0, MIT, approved, #14411
 maven/mavencentral/com.microsoft.azure/msal4j/1.15.0, MIT, approved, clearlydefined
 maven/mavencentral/com.microsoft.azure/msal4j/1.16.2, MIT, approved, clearlydefined
@@ -278,7 +278,7 @@ maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.assertj/assertj-core/3.26.0, Apache-2.0, approved, #14886
 maven/mavencentral/org.assertj/assertj-core/3.26.3, Apache-2.0, approved, #14886
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, #14178
-maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
+maven/mavencentral/org.awaitility/awaitility/4.2.2, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78.1, MIT, approved, #14434
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78.1, MIT AND CC0-1.0, approved, #14433
@@ -376,6 +376,7 @@ maven/mavencentral/org.eclipse.edc/json-ld/0.8.2-SNAPSHOT, Apache-2.0, approved,
 maven/mavencentral/org.eclipse.edc/json-lib/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit-base/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-signer-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/keys-lib/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/keys-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -453,15 +454,15 @@ maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined

--- a/extensions/common/azure/azure-eventgrid/src/main/java/org/eclipse/edc/azure/event/AzureEventExtension.java
+++ b/extensions/common/azure/azure-eventgrid/src/main/java/org/eclipse/edc/azure/event/AzureEventExtension.java
@@ -62,7 +62,7 @@ public class AzureEventExtension implements ServiceExtension {
                 .buildEventGridEventPublisherAsyncClient();
 
 
-        var publisher = new AzureEventGridPublisher(context.getConnectorId(), monitor, publisherClient);
+        var publisher = new AzureEventGridPublisher(context.getComponentId(), monitor, publisherClient);
 
         var processObservable = context.getService(TransferProcessObservable.class, true);
         if (processObservable != null) {

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/metadata/CommonBlobMetadataDecorator.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/metadata/CommonBlobMetadataDecorator.java
@@ -42,7 +42,7 @@ public class CommonBlobMetadataDecorator implements BlobMetadataDecorator {
         builder.put(ORIGINAL_NAME, part.name())
                 .put(REQUEST_ID, request.getId())
                 .put(PROCESS_ID, request.getProcessId())
-                .put(CONNECTOR_ID, context.getConnectorId())
+                .put(CONNECTOR_ID, context.getComponentId())
                 .put(PARTICIPANT_ID, context.getParticipantId());
 
         var dataAddress = request.getDestinationDataAddress();

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/AzureDataPlaneCopyIntegrationTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/AzureDataPlaneCopyIntegrationTest.java
@@ -139,7 +139,7 @@ class AzureDataPlaneCopyIntegrationTest extends AbstractAzureBlobTest {
 
         var metadataProvider = new BlobMetadataProviderImpl(monitor);
         metadataProvider.registerDecorator(new CommonBlobMetadataDecorator(typeManager, context));
-        when(context.getConnectorId()).thenReturn("connector-id");
+        when(context.getComponentId()).thenReturn("connector-id");
         when(context.getParticipantId()).thenReturn("participant-id");
         var dataSinkFactory = new AzureStorageDataSinkFactory(account2ApiPatched, executor, partitionSize, monitor, vault, typeManager, metadataProvider);
         var dataSink = dataSinkFactory.createSink(request);

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/metadata/CommonBlobMetadataDecoratorTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/metadata/CommonBlobMetadataDecoratorTest.java
@@ -66,7 +66,7 @@ public class CommonBlobMetadataDecoratorTest {
             }
         };
 
-        when(context.getConnectorId()).thenReturn(TEST_CONNECTOR_ID);
+        when(context.getComponentId()).thenReturn(TEST_CONNECTOR_ID);
         when(context.getParticipantId()).thenReturn(TEST_PARTICIPANT_ID);
 
         var decorator = new CommonBlobMetadataDecorator(typeManager, context);

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureDataSourceToDataSinkTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureDataSourceToDataSinkTest.java
@@ -108,7 +108,7 @@ class AzureDataSourceToDataSinkTest {
                 sharedAccessSignatureMatcher(sinkSharedAccessSignature)
         )).thenReturn(fakeCompletionMarker);
 
-        when(context.getConnectorId()).thenReturn("connectorId");
+        when(context.getComponentId()).thenReturn("connectorId");
         when(context.getParticipantId()).thenReturn("participantId");
 
         var metadataProvider = new BlobMetadataProviderImpl(monitor);
@@ -170,7 +170,7 @@ class AzureDataSourceToDataSinkTest {
                 sharedAccessSignatureMatcher(sinkSharedAccessSignature)
         )).thenReturn(fakeSink);
 
-        when(context.getConnectorId()).thenReturn("connectorId");
+        when(context.getComponentId()).thenReturn("connectorId");
         when(context.getParticipantId()).thenReturn("participantId");
 
         var metadataProvider = new BlobMetadataProviderImpl(monitor);
@@ -226,7 +226,7 @@ class AzureDataSourceToDataSinkTest {
         when(blobApi.getBlobAdapter(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(blobAdapter);
 
-        when(context.getConnectorId()).thenReturn("connectorId");
+        when(context.getComponentId()).thenReturn("connectorId");
         when(context.getParticipantId()).thenReturn("participantId");
 
         var metadataProvider = new BlobMetadataProviderImpl(monitor);

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkTest.java
@@ -120,7 +120,7 @@ class AzureStorageDataSinkTest {
                 sharedAccessSignatureMatcher(sharedAccessSignature)))
                 .thenReturn(completionMarker);
 
-        when(context.getConnectorId()).thenReturn("connectorId");
+        when(context.getComponentId()).thenReturn("connectorId");
         when(context.getParticipantId()).thenReturn("participantId");
         when(destinationBlobName.resolve(blobName, 1)).thenReturn(blobName);
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a temporary fix to update the `gradle/libs.version.toml` version catalog before a version is published. 
Specifically, it passes the version string to `verify.yaml`, so that tests are executed using the given upstream EDC modules, and it updates `gradle.properties`, `gradle/libs.versions.toml` and `DEPENDENCIES` before the Maven artefacts are published.

In addition, the release job (`release-tech-aws.yaml`) only bumps the version if it was a "release" version (not a hotfix/bugfix or a snapshot).

## Why it does that

employ a temporary fix until a restructuring of the release workflow can be implemented.

## Further notes

I intentionally did not extract the `sed` command in a re-usable action, because it is a temporary fix anyway, and it is better if it sticks out like a sore thumb

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._

