### PR TITLE
fix(provision): AZBlob provisioner honors `folderName`

### DIFF
--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResource.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedData
 
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.ACCOUNT_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.FOLDER_NAME;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 @JsonDeserialize(builder = ObjectContainerProvisionedResource.Builder.class)
@@ -70,5 +71,11 @@ public class ObjectContainerProvisionedResource extends ProvisionedDataDestinati
             return this;
         }
 
+        public Builder folderName(String folderName) {
+            if (folderName != null) {
+                dataAddressBuilder.property(EDC_NAMESPACE + FOLDER_NAME, folderName);
+            }
+            return this;
+        }
     }
 }

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
@@ -33,11 +33,17 @@ public class ObjectStorageConsumerResourceDefinitionGenerator implements Consume
         var id = randomUUID().toString();
         var account = destination.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
         var container = destination.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME);
+        var folderName = destination.getStringProperty(AzureBlobStoreSchema.FOLDER_NAME);
 
         if (container == null) {
             container = randomUUID().toString();
         }
-        return ObjectStorageResourceDefinition.Builder.newInstance().id(id).accountName(account).containerName(container).build();
+        return ObjectStorageResourceDefinition.Builder.newInstance()
+                .id(id)
+                .accountName(account)
+                .containerName(container)
+                .folderName(folderName)
+                .build();
     }
 
     @Override

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageProvisioner.java
@@ -57,6 +57,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
     public CompletableFuture<StatusResult<ProvisionResponse>> provision(ObjectStorageResourceDefinition resourceDefinition, Policy policy) {
         String containerName = resourceDefinition.getContainerName();
         String accountName = resourceDefinition.getAccountName();
+        String folderName = resourceDefinition.getFolderName();
 
         monitor.debug("Azure Storage Container request submitted: " + containerName);
 
@@ -78,6 +79,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
                             .id(containerName)
                             .accountName(accountName)
                             .containerName(containerName)
+                            .folderName(folderName)
                             .resourceDefinitionId(resourceDefinition.getId())
                             .transferProcessId(resourceDefinition.getTransferProcessId())
                             .resourceName(resourceName)

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinition.java
@@ -24,6 +24,7 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
 
     private String containerName;
     private String accountName;
+    private String folderName;
 
     public String getContainerName() {
         return containerName;
@@ -37,7 +38,12 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
     public Builder toBuilder() {
         return initializeBuilder(new Builder())
                 .containerName(containerName)
+                .folderName(folderName)
                 .accountName(accountName);
+    }
+
+    public String getFolderName() {
+        return folderName;
     }
 
     public static class Builder extends ResourceDefinition.Builder<ObjectStorageResourceDefinition, Builder> {
@@ -57,6 +63,11 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
 
         public Builder accountName(String accountName) {
             resourceDefinition.accountName = accountName;
+            return this;
+        }
+
+        public Builder folderName(String folderName) {
+            resourceDefinition.folderName = folderName;
             return this;
         }
 

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGeneratorTest.java
@@ -50,6 +50,28 @@ class ObjectStorageConsumerResourceDefinitionGeneratorTest {
         assertThat(objectDef.getAccountName()).isEqualTo("test-account");
         assertThat(objectDef.getContainerName()).isEqualTo("test-container");
         assertThat(objectDef.getId()).satisfies(UUID::fromString);
+        assertThat(objectDef.getFolderName()).isNull();
+    }
+
+    @Test
+    void generate_withContainerName_andFolder() {
+        var destination = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE)
+                .property(AzureBlobStoreSchema.CONTAINER_NAME, "test-container")
+                .property(AzureBlobStoreSchema.ACCOUNT_NAME, "test-account")
+                .property(AzureBlobStoreSchema.FOLDER_NAME, "test-folder")
+                .build();
+        var asset = Asset.Builder.newInstance().build();
+        var transferProcess = TransferProcess.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = generator.generate(transferProcess, policy);
+
+        assertThat(definition).isInstanceOf(ObjectStorageResourceDefinition.class);
+        var objectDef = (ObjectStorageResourceDefinition) definition;
+        assertThat(objectDef.getAccountName()).isEqualTo("test-account");
+        assertThat(objectDef.getContainerName()).isEqualTo("test-container");
+        assertThat(objectDef.getId()).satisfies(UUID::fromString);
+        assertThat(objectDef.getFolderName()).isEqualTo("test-folder");
     }
 
     @Test

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
@@ -14,19 +14,24 @@
 
 package org.eclipse.edc.connector.provision.azure.blob;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ObjectStorageResourceDefinitionTest {
 
-    @Test
-    void toBuilder_verifyEqualResourceDefinition() {
+    @ParameterizedTest
+    @ValueSource(strings = { "test-folder" })
+    @NullAndEmptySource
+    void toBuilder_verifyEqualResourceDefinition(String folder) {
         var definition = ObjectStorageResourceDefinition.Builder.newInstance()
                 .id("id")
                 .transferProcessId("tp-id")
                 .accountName("account")
                 .containerName("container")
+                .folderName(folder)
                 .build();
         var builder = definition.toBuilder();
         var rebuiltDefinition = builder.build();

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
-import org.eclipse.edc.util.string.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ExecutorService;
@@ -113,8 +112,8 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
             validateContainerName(dataAddress.getStringProperty(CONTAINER_NAME));
             validateKeyName(dataAddress.getKeyName());
             if (dataSourceAddress.hasProperty(BLOB_PREFIX)) {
-                if (!StringUtils.isNullOrBlank(BLOB_NAME)) {
-                    monitor.warning(String.format("Folder transfer, ignoring property %s", BLOB_NAME));
+                if (dataSourceAddress.hasProperty(BLOB_NAME)) {
+                    monitor.warning("Folder transfer (property '%s' is present), will ignore the blob name (property '%s')".formatted(BLOB_PREFIX, BLOB_NAME));
                 }
             }
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
## What this PR changes/adds

The `ObjectStorageProvisioner` and associated classes now honor the somewhat recently introduced `folderName` property

## Why it does that

not possible to specify a folder name otherwise

## Further notes

- fixes an erroneous log line

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
