### PR TITLE
fix: throw exception if SAS token secret is null

### DIFF
--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -83,7 +83,7 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
 
         var secret = vault.resolveSecret(dataAddress.getKeyName());
 
-        if(secret == null){
+        if (secret == null) {
             throw new EdcException("SAS token for the Azure Blob DataSink not found in Vault (alias = '%s')".formatted(dataAddress.getKeyName()));
         }
 

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -82,6 +82,11 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
         var requestId = request.getId();
 
         var secret = vault.resolveSecret(dataAddress.getKeyName());
+
+        if(secret == null){
+            throw new EdcException("SAS token for the Azure Blob DataSink not found in Vault (alias = '%s')".formatted(dataAddress.getKeyName()));
+        }
+
         var token = typeManager.readValue(secret, AzureSasToken.class);
         var folderName = dataAddress.getStringProperty(AzureBlobStoreSchema.FOLDER_NAME);
         var blobName = dataAddress.getStringProperty(AzureBlobStoreSchema.BLOB_NAME);

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -32,12 +32,15 @@ import java.util.Random;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createAccountName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobPrefix;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createRequest;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +57,8 @@ class AzureStorageDataSinkFactoryTest {
 
     private final String accountName = createAccountName();
     private final String containerName = createContainerName();
-    private final String blobName = createBlobName();
+
+
     private final String blobPrefix = createBlobPrefix();
     private final String keyName = "test-keyname";
     private final AzureSasToken token = new AzureSasToken("test-writeonly-sas", new Random().nextLong());
@@ -135,6 +139,21 @@ class AzureStorageDataSinkFactoryTest {
 
     @Test
     void createSink_whenInvalidRequest_fails() {
-        assertThrows(EdcException.class, () -> factory.createSink(invalidRequest.build()));
+        assertThatThrownBy(() -> factory.createSink(invalidRequest.build()))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("AzureStorage destination address is invalid: Invalid account name, the name may not be null, empty or blank");
+    }
+
+    @Test
+    void createSink_whenSecretNotFoundRequest_fails() {
+        when(vault.resolveSecret(anyString())).thenReturn(null);
+        var validRequest = request.destinationDataAddress(dataAddress
+                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
+                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
+                .keyName(keyName)
+                .build());
+        assertThatThrownBy(() -> factory.createSink(validRequest.build()))
+                .isInstanceOf(EdcException.class)
+                .hasMessageStartingWith("SAS token for the Azure Blob DataSink not found in Vault");
     }
 }

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -34,13 +34,10 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createAccountName;
-import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createBlobPrefix;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.edc.azure.blob.testfixtures.AzureStorageTestFixtures.createRequest;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
improves error reporting when a secret is not found in the vault

## Why it does that

better traceability of errors

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #254

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
