### PR TITLE
chore: disable nightly Cosmos tests

### DIFF
--- a/.github/workflows/run-cosmos-tests.yaml
+++ b/.github/workflows/run-cosmos-tests.yaml
@@ -1,10 +1,11 @@
 name: Run Cosmos Tests
 on:
-  schedule:
-    # run daily at midnight
-    - cron: 0 0 * * *
+  # disabling scheduled runs for now
+  # schedule:
+  # run daily at midnight
+  #  - cron: 0 0 * * *
   workflow_dispatch:
-    
+
 
 jobs:
   Check-Actions-Secrets:


### PR DESCRIPTION
## What this PR changes/adds

disables the nightly Cosmos tests.

## Why it does that

those tests have been broken for a long time. the test should be re-enabled, once they are fixed.

in addition, the Azure Cosmos subscription needs to be migrated to another tenant, which will take some time. The GH secret `PG_CONNECTION_STRING` will also be deleted.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
