### PR TITLE
fix(docs): Update README.md to exclude "properties" key from dataAddress and dataDestination

### DIFF
--- a/extensions/data-plane/data-plane-azure-storage/README.md
+++ b/extensions/data-plane/data-plane-azure-storage/README.md
@@ -27,13 +27,11 @@ An example source address:
 ```json
 {
   "dataAddress": {
-    "properties": {
-      "type": "AzureStorage",
-      "container": "containerName",
-      "account": "accountName",
-      "blobName": "test/blob.bin",
-      "keyName": "(see above)"
-    }
+    "type": "AzureStorage",
+    "container": "containerName",
+    "account": "accountName",
+    "blobName": "test/blob.bin",
+    "keyName": "(see above)"
   }
 }
 ```
@@ -41,13 +39,11 @@ An example source address:
 ```json
 {
   "dataAddress": {
-    "properties": {
-      "type": "AzureStorage",
-      "container": "containerName",
-      "account": "accountName",
-      "blobPrefix": "test/",
-      "keyName": "(see above)"
-    }
+    "type": "AzureStorage",
+    "container": "containerName",
+    "account": "accountName",
+    "blobPrefix": "test/",
+    "keyName": "(see above)"
   }
 }
 ```
@@ -57,14 +53,12 @@ An example destination address:
 ```json
 {
     "dataDestination": {
-        "properties": {
-            "type": "AzureStorage",
-            "container": "containerName",
-            "account": "accountName",
-            "folderName": "destinationFolder/",
-            "blobName": "new-name",
-            "keyName": "(see above)"
-        }
+      "type": "AzureStorage",
+      "container": "containerName",
+      "account": "accountName",
+      "folderName": "destinationFolder/",
+      "blobName": "new-name",
+      "keyName": "(see above)"
     }
 }
 ```
@@ -73,18 +67,15 @@ An example destination address:
 ```json
 {
     "dataDestination": {
-        "properties": {
-            "type": "AzureStorage",
-            "container": "containerName",
-            "account": "accountName",
-            "folderName": "destinationFolder/",
-            "keyName": "(see above)"
-        }
+      "type": "AzureStorage",
+      "container": "containerName",
+      "account": "accountName",
+      "folderName": "destinationFolder/",
+      "keyName": "(see above)"
     }
 }
 ```
 The `folderName` and the `blobName` are optional properties in destination address.
-
 
 
 ### AzureStorage Transfer Configuration


### PR DESCRIPTION

## What this PR changes/adds

_Briefly describe WHAT your pr changes, which features it adds/modifies._

Removed the "properties" key.


## Why it does that

_Briefly state why the change was necessary._

The "properties" key in the dataAddress or Destination is not required and will lead to errors when creating the asset. 


## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
