### PR TITLE
fix: add missing annotations on `ObjectStorageResourceDefinition` to permit json serdes

### DIFF
--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinition.java
@@ -16,10 +16,13 @@
 package org.eclipse.edc.connector.provision.azure.blob;
 
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ResourceDefinition;
 
 import java.util.Objects;
 
+@JsonDeserialize(builder = ObjectStorageResourceDefinition.Builder.class)
 public class ObjectStorageResourceDefinition extends ResourceDefinition {
 
     private String containerName;
@@ -46,6 +49,7 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
         return folderName;
     }
 
+    @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ResourceDefinition.Builder<ObjectStorageResourceDefinition, Builder> {
 
         private Builder() {

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
@@ -14,9 +14,15 @@
 
 package org.eclipse.edc.connector.provision.azure.blob;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ResourceManifest;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,4 +45,23 @@ class ObjectStorageResourceDefinitionTest {
         assertThat(rebuiltDefinition).usingRecursiveComparison().isEqualTo(definition);
     }
 
+    @Test
+    void serdes() throws JsonProcessingException {
+        var typeManager = new JacksonTypeManager();
+        typeManager.registerTypes(ObjectStorageResourceDefinition.class);
+        var objectMapper = typeManager.getMapper();
+        var definition = ObjectStorageResourceDefinition.Builder.newInstance()
+                .id("id")
+                .transferProcessId("tp-id")
+                .accountName("account")
+                .containerName("container")
+                .folderName("any")
+                .build();
+        var manifest = ResourceManifest.Builder.newInstance().definitions(List.of(definition)).build();
+
+        var json = objectMapper.writeValueAsString(manifest);
+        var deserialized = objectMapper.readValue(json, ResourceManifest.class);
+
+        assertThat(deserialized.getDefinitions().get(0)).usingRecursiveComparison().isEqualTo(definition);
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Add missing annotations to `ObjectStorageResourceDefinition`

## Why it does that

permit correct serdes

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #338 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
