### PR TITLE
feat: added blobName to provisioned resource

### DIFF
--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResource.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.azure.blob.AzureBlobStoreSchema;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataDestinationResource;
 
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.ACCOUNT_NAME;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.FOLDER_NAME;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
@@ -74,6 +75,13 @@ public class ObjectContainerProvisionedResource extends ProvisionedDataDestinati
         public Builder folderName(String folderName) {
             if (folderName != null) {
                 dataAddressBuilder.property(EDC_NAMESPACE + FOLDER_NAME, folderName);
+            }
+            return this;
+        }
+
+        public Builder blobName(String blobName) {
+            if (blobName != null) {
+                dataAddressBuilder.property(EDC_NAMESPACE + BLOB_NAME, blobName);
             }
             return this;
         }

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
@@ -47,7 +47,8 @@ public class ObjectStorageConsumerResourceDefinitionGenerator implements Consume
             definitionBuilder
                     .accountName(destination.getStringProperty(AzureBlobStoreSchema.ACCOUNT_NAME))
                     .containerName(destination.getStringProperty(AzureBlobStoreSchema.CONTAINER_NAME, randomUUID().toString()))
-                    .folderName(destination.getStringProperty(AzureBlobStoreSchema.FOLDER_NAME));
+                    .folderName(destination.getStringProperty(AzureBlobStoreSchema.FOLDER_NAME))
+                    .blobName(destination.getStringProperty(AzureBlobStoreSchema.BLOB_NAME));
         }
 
         return definitionBuilder.build();

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageProvisioner.java
@@ -61,6 +61,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
         String containerName = resourceDefinition.getContainerName();
         String accountName = resourceDefinition.getAccountName();
         String folderName = resourceDefinition.getFolderName();
+        String blobName = resourceDefinition.getBlobName();
 
         monitor.debug("Azure Storage Container request submitted: " + containerName);
 
@@ -83,6 +84,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
                             .accountName(accountName)
                             .containerName(containerName)
                             .folderName(folderName)
+                            .blobName(blobName)
                             .resourceDefinitionId(resourceDefinition.getId())
                             .transferProcessId(resourceDefinition.getTransferProcessId())
                             .resourceName(resourceName)

--- a/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-blob/src/main/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinition.java
@@ -28,6 +28,7 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
     private String containerName;
     private String accountName;
     private String folderName;
+    private String blobName;
 
     public String getContainerName() {
         return containerName;
@@ -42,11 +43,16 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
         return initializeBuilder(new Builder())
                 .containerName(containerName)
                 .folderName(folderName)
+                .blobName(blobName)
                 .accountName(accountName);
     }
 
     public String getFolderName() {
         return folderName;
+    }
+
+    public String getBlobName() {
+        return blobName;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -72,6 +78,11 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
 
         public Builder folderName(String folderName) {
             resourceDefinition.folderName = folderName;
+            return this;
+        }
+
+        public Builder blobName(String blobName) {
+            resourceDefinition.blobName = blobName;
             return this;
         }
 

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResourceTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectContainerProvisionedResourceTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.ACCOUNT_NAME;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.CONTAINER_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.FOLDER_NAME;
 
@@ -54,17 +55,22 @@ class ObjectContainerProvisionedResourceTest {
         assertThat(dest.getStringProperty(CONTAINER_NAME)).isEqualTo("test-container");
         assertThat(dest.getStringProperty(ACCOUNT_NAME)).isEqualTo("test-account");
         assertThat(dest.getProperties()).doesNotContainKey(FOLDER_NAME);
+        assertThat(dest.getProperties()).doesNotContainKey(BLOB_NAME);
     }
 
     @Test
-    void createDataDestination_withFolder() {
-        var dest = builder.folderName("testfolder").build().getDataAddress();
+    void createDataDestination_withFolderAndBlob() {
+        var dest = builder
+                .folderName("testfolder")
+                .blobName("testblob")
+                .build().getDataAddress();
 
         assertThat(dest.getType()).isEqualTo(AzureBlobStoreSchema.TYPE);
         assertThat(dest.getKeyName()).isEqualTo("test-container");
         assertThat(dest.getStringProperty(CONTAINER_NAME)).isEqualTo("test-container");
         assertThat(dest.getStringProperty(ACCOUNT_NAME)).isEqualTo("test-account");
         assertThat(dest.getStringProperty(FOLDER_NAME)).isEqualTo("testfolder");
+        assertThat(dest.getStringProperty(BLOB_NAME)).isEqualTo("testblob");
     }
 
 
@@ -84,6 +90,8 @@ class ObjectContainerProvisionedResourceTest {
 
     @Test
     void verifyDeserialization() {
+        var enrichedBuilder = builder.blobName("test-blob").folderName("test-folder");
+
         var serialized = Map.of(
                 "id", "test-id",
                 "edctype", "dataspaceconnector:objectcontainerprovisionedresource",
@@ -91,7 +99,9 @@ class ObjectContainerProvisionedResourceTest {
                 "resourceDefinitionId", "test-resdef-id",
                 "accountName", "test-account",
                 "containerName", "test-container",
-                "resourceName", "test-container"
+                "resourceName", "test-container",
+                "folderName", "test-folder",
+                "blobName", "test-blob"
         );
 
         var res = typeManager.readValue(typeManager.writeValueAsBytes(serialized), ObjectContainerProvisionedResource.class);
@@ -99,6 +109,7 @@ class ObjectContainerProvisionedResourceTest {
         assertThat(res).isNotNull();
         assertThat(res.getContainerName()).isEqualTo("test-container");
         assertThat(res.getAccountName()).isEqualTo("test-account");
-        assertThat(res).usingRecursiveComparison().isEqualTo(builder.build());
+        assertThat(res).usingRecursiveComparison().isEqualTo(enrichedBuilder.build());
     }
+
 }

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGeneratorTest.java
@@ -62,14 +62,16 @@ class ObjectStorageConsumerResourceDefinitionGeneratorTest {
             assertThat(objectDef.getContainerName()).isEqualTo("test-container");
             assertThat(objectDef.getId()).satisfies(UUID::fromString);
             assertThat(objectDef.getFolderName()).isNull();
+            assertThat(objectDef.getBlobName()).isNull();
         }
 
         @Test
-        void generate_withContainerName_andFolder() {
+        void generate_withContainerName_andFolder_andBlobName() {
             var destination = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE)
                     .property(AzureBlobStoreSchema.CONTAINER_NAME, "test-container")
                     .property(AzureBlobStoreSchema.ACCOUNT_NAME, "test-account")
                     .property(AzureBlobStoreSchema.FOLDER_NAME, "test-folder")
+                    .property(AzureBlobStoreSchema.BLOB_NAME, "test-blob")
                     .build();
             var asset = Asset.Builder.newInstance().build();
             var transferProcess = TransferProcess.Builder.newInstance()
@@ -86,6 +88,7 @@ class ObjectStorageConsumerResourceDefinitionGeneratorTest {
             assertThat(objectDef.getContainerName()).isEqualTo("test-container");
             assertThat(objectDef.getId()).satisfies(UUID::fromString);
             assertThat(objectDef.getFolderName()).isEqualTo("test-folder");
+            assertThat(objectDef.getBlobName()).isEqualTo("test-blob");
         }
 
         @Test

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageProvisionerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.BLOB_NAME;
 import static org.eclipse.edc.azure.blob.AzureBlobStoreSchema.FOLDER_NAME;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.mockito.ArgumentMatchers.any;
@@ -81,8 +82,12 @@ class ObjectStorageProvisionerTest {
     }
 
     @Test
-    void provision_withFolder_success() {
-        var resourceDef = createResourceDefinitionBuilder().transferProcessId("tpId").folderName("test-folder").build();
+    void provision_withFolder_andBlob_success() {
+        var resourceDef = createResourceDefinitionBuilder()
+                .transferProcessId("tpId")
+                .folderName("test-folder")
+                .blobName("test-blob")
+                .build();
         String accountName = resourceDef.getAccountName();
         String containerName = resourceDef.getContainerName();
         when(blobStoreApiMock.exists(anyString(), anyString())).thenReturn(false);
@@ -93,6 +98,7 @@ class ObjectStorageProvisionerTest {
         assertThat(response.getResource()).isInstanceOfSatisfying(ObjectContainerProvisionedResource.class, resource -> {
             assertThat(resource.getTransferProcessId()).isEqualTo("tpId");
             assertThat(resource.getDataAddress().getStringProperty(EDC_NAMESPACE + FOLDER_NAME)).isEqualTo("test-folder");
+            assertThat(resource.getDataAddress().getStringProperty(EDC_NAMESPACE + BLOB_NAME)).isEqualTo("test-blob");
         });
         assertThat(response.getSecretToken()).isInstanceOfSatisfying(AzureSasToken.class, secretToken -> {
             assertThat(secretToken.getSas()).isEqualTo("?some-sas");

--- a/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
+++ b/extensions/control-plane/provision/provision-blob/src/test/java/org/eclipse/edc/connector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
@@ -38,6 +38,7 @@ class ObjectStorageResourceDefinitionTest {
                 .accountName("account")
                 .containerName("container")
                 .folderName(folder)
+                .blobName("blob")
                 .build();
         var builder = definition.toBuilder();
         var rebuiltDefinition = builder.build();
@@ -56,6 +57,7 @@ class ObjectStorageResourceDefinitionTest {
                 .accountName("account")
                 .containerName("container")
                 .folderName("any")
+                .blobName("blob")
                 .build();
         var manifest = ResourceManifest.Builder.newInstance().definitions(List.of(definition)).build();
 


### PR DESCRIPTION
## What this PR changes/adds

Adds the blobName to a provisoned resource definition.

## Why it does that

When a consumer provisions a resource for a data transfer, the `dataDestination` of the transfer request will be overwritten with the provisioned resource definition. The blobName was missing from the definition, hence the blobName could never be changed in a provisioned destination.

## Further notes

Also removed dead code.

## Who will sponsor this feature?

@ndr-brt ?

## Linked Issue(s)

Closes #333 
