### PR TITLE
fix: remove `-key1` suffix

### DIFF
--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/cache/AccountCacheImpl.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/edc/azure/blob/cache/AccountCacheImpl.java
@@ -44,7 +44,7 @@ public class AccountCacheImpl implements AccountCache {
             return getAccount(accountName);
         }
 
-        var accountKey = vault.resolveSecret(accountName + "-key1");
+        var accountKey = vault.resolveSecret(accountName);
 
         return saveAccount(accountName, accountKey);
     }

--- a/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryCopyIntegrationTest.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/AzureDataFactoryCopyIntegrationTest.java
@@ -122,7 +122,7 @@ class AzureDataFactoryCopyIntegrationTest {
                 .property(ACCOUNT_NAME, providerStorage.name)
                 .property(CONTAINER_NAME, providerStorage.containerName)
                 .property(BLOB_NAME, blobName)
-                .keyName(providerStorage.name + "-key1")
+                .keyName(providerStorage.name)
                 .build();
 
         var destSecretKeyName = consumerStorage.name + "-ittest-sas-" + UUID.randomUUID();

--- a/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/TestFunctions.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/test/java/org/eclipse/edc/connector/dataplane/azure/datafactory/TestFunctions.java
@@ -32,7 +32,7 @@ public class TestFunctions {
         var srcStorageAccount = createAccountName();
         return DataAddress.Builder.newInstance()
                 .type(AzureBlobStoreSchema.TYPE)
-                .keyName(srcStorageAccount + "-key1")
+                .keyName(srcStorageAccount)
                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, srcStorageAccount)
                 .property(AzureBlobStoreSchema.CONTAINER_NAME, createContainerName())
                 .property(AzureBlobStoreSchema.BLOB_NAME, createBlobName())
@@ -45,7 +45,7 @@ public class TestFunctions {
 
         return DataAddress.Builder.newInstance()
                 .type(AzureBlobStoreSchema.TYPE)
-                .keyName(destStorageAccount + "-key1")
+                .keyName(destStorageAccount)
                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, destStorageAccount)
                 .property(AzureBlobStoreSchema.CONTAINER_NAME, createContainerName())
                 .build()

--- a/extensions/data-plane/data-plane-azure-storage/README.md
+++ b/extensions/data-plane/data-plane-azure-storage/README.md
@@ -87,6 +87,11 @@ An example destination address:
 
 The `folderName` and the `blobName` are optional properties in destination address.
 
+### Transfer Provisioning
+
+When provisioning a transfer, the key with the value of `account` will be resolved from the vault.
+This key will be used to authenticate with Azure. If such a key is not present environment/system variables will be used.
+
 ### AzureStorage Transfer Configuration
 
 The existing implementation takes under consideration transfer of files up to 200GB and that can be accomplished within

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/AzureDataPlaneCopyIntegrationTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/AzureDataPlaneCopyIntegrationTest.java
@@ -124,7 +124,7 @@ class AzureDataPlaneCopyIntegrationTest extends AbstractAzureBlobTest {
                 .keyName(account2KeyName)
                 .build();
 
-        when(vault.resolveSecret(CONSUMER_STORAGE_ACCOUNT_NAME + "-key1"))
+        when(vault.resolveSecret(CONSUMER_STORAGE_ACCOUNT_NAME))
                 .thenReturn(CONSUMER_STORAGE_ACCOUNT_KEY);
 
         var account2SasToken = account2Api.createContainerSasToken(CONSUMER_STORAGE_ACCOUNT_NAME, sinkContainerName,

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
@@ -49,7 +49,7 @@ class AzureStorageDataSourceFactoryTest {
     @Test
     void validate_whenBlobRequestValid_succeeds() {
         assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
-                                .keyName(accountName + "-key1")
+                                .keyName(accountName)
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
@@ -61,7 +61,7 @@ class AzureStorageDataSourceFactoryTest {
     @Test
     void validate_whenBlobFolderRequestValid_succeeds() {
         assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
-                                .keyName(accountName + "-key1")
+                                .keyName(accountName)
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .property(AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix)

--- a/resources/azure/testing/terraform/main.tf
+++ b/resources/azure/testing/terraform/main.tf
@@ -103,7 +103,7 @@ resource "azurerm_role_assignment" "data_factory" {
 
 ## Store provider storage account accesss key seceret
 resource "azurerm_key_vault_secret" "provider_storage_key" {
-  name         = "${azurerm_storage_account.provider.name}-key1"
+  name         = azurerm_storage_account.provider.name
   value        = azurerm_storage_account.provider.primary_access_key
   key_vault_id = azurerm_key_vault.main.id
   depends_on   = [
@@ -113,7 +113,7 @@ resource "azurerm_key_vault_secret" "provider_storage_key" {
 
 ## Store consumer storage account accesss key seceret
 resource "azurerm_key_vault_secret" "consumer_storage_key" {
-  name         = "${azurerm_storage_account.consumer.name}-key1"
+  name         = azurerm_storage_account.consumer.name
   value        = azurerm_storage_account.consumer.primary_access_key
   key_vault_id = azurerm_key_vault.main.id
   depends_on   = [

--- a/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
+++ b/system-tests/azure-blob-transfer-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/blob/BlobTransferParticipant.java
@@ -69,7 +69,7 @@ public class BlobTransferParticipant extends Participant {
                 AzureBlobStoreSchema.ACCOUNT_NAME, accountName,
                 AzureBlobStoreSchema.CONTAINER_NAME, containerName,
                 AzureBlobStoreSchema.BLOB_NAME, blobName,
-                "keyName", format("%s-key1", accountName)
+                "keyName", accountName
         );
 
         Map<String, Object> properties = Map.of(
@@ -89,7 +89,7 @@ public class BlobTransferParticipant extends Participant {
                 AzureBlobStoreSchema.ACCOUNT_NAME, accountName,
                 AzureBlobStoreSchema.CONTAINER_NAME, containerName,
                 AzureBlobStoreSchema.BLOB_PREFIX, blobPrefix,
-                "keyName", format("%s-key1", accountName)
+                "keyName", accountName
         );
 
         Map<String, Object> properties = Map.of(

--- a/system-tests/azure-blob-transfer-tests/src/test/java/org/eclipse/edc/test/system/blob/BlobTransferIntegrationTest.java
+++ b/system-tests/azure-blob-transfer-tests/src/test/java/org/eclipse/edc/test/system/blob/BlobTransferIntegrationTest.java
@@ -97,8 +97,8 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
         PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), policyId, policyId);
 
         // Write Key to vault
-        CONSUMER_RUNTIME.getService(Vault.class).storeSecret(format("%s-key1", CONSUMER_STORAGE_ACCOUNT_NAME), CONSUMER_STORAGE_ACCOUNT_KEY);
-        PROVIDER_RUNTIME.getService(Vault.class).storeSecret(format("%s-key1", PROVIDER_STORAGE_ACCOUNT_NAME), PROVIDER_STORAGE_ACCOUNT_KEY);
+        CONSUMER_RUNTIME.getService(Vault.class).storeSecret(CONSUMER_STORAGE_ACCOUNT_NAME, CONSUMER_STORAGE_ACCOUNT_KEY);
+        PROVIDER_RUNTIME.getService(Vault.class).storeSecret(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_STORAGE_ACCOUNT_KEY);
 
         var transferProcessId = CONSUMER.requestAssetAndTransferToBlob(PROVIDER, assetId, CONSUMER_STORAGE_ACCOUNT_NAME);
         await().pollInterval(POLL_INTERVAL).atMost(TIMEOUT).untilAsserted(() -> {

--- a/system-tests/azure-data-factory-tests/src/test/java/org/eclipse/edc/test/system/blob/AzureDataFactoryTransferIntegrationTest.java
+++ b/system-tests/azure-data-factory-tests/src/test/java/org/eclipse/edc/test/system/blob/AzureDataFactoryTransferIntegrationTest.java
@@ -148,7 +148,7 @@ class AzureDataFactoryTransferIntegrationTest {
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .buildClient();
         var vault = new AzureVault(new ConsoleMonitor(), secretClient);
-        var consumerAccountKey = Objects.requireNonNull(vault.resolveSecret(format("%s-key1", consumerStorageAccountName)));
+        var consumerAccountKey = Objects.requireNonNull(vault.resolveSecret(consumerStorageAccountName));
         var blobStoreApi = new BlobStoreApiImpl(vault, BLOB_STORE_CORE_EXTENSION_CONFIG);
 
         // Upload a blob with test data on provider blob container


### PR DESCRIPTION
## What this PR changes/adds

Removes the `-key1` suffix used to look up credentials from the vault when provisioning a transfer.

## Why it does that

The suffix is not really necessary and was not documented anywhere

## Linked Issue(s)

Closes #372
